### PR TITLE
Deleted unused var & added cmd+... shortcut for macOS

### DIFF
--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -67,7 +67,7 @@ export default {
   },
   mounted: function() {
     document.addEventListener("keydown", e => {
-      if (e.ctrlKey) {
+      if (e.ctrlKey || e.metaKey) {
         const appEl = document.querySelector("#app");
         if (e.keyCode === 39 && this.active < this.slides.length - 1) {
           appEl.style.setProperty("--slide-in", "300px");

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -70,10 +70,13 @@ export default {
       if (e.ctrlKey || e.metaKey) {
         const appEl = document.querySelector("#app");
         if (e.keyCode === 39 && this.active < this.slides.length - 1) {
+          // cmd + left arrow will return to last webpage by default, should be prevented
+          e.preventDefault();
           appEl.style.setProperty("--slide-in", "300px");
           appEl.style.setProperty("--slide-out", "-300px");
           this.active++;
         } else if (e.keyCode === 37 && this.active > 0) {
+          e.preventDefault();
           appEl.style.setProperty("--slide-in", "-300px");
           appEl.style.setProperty("--slide-out", "300px");
           this.active--;

--- a/demo/src/components/DoubleCode.vue
+++ b/demo/src/components/DoubleCode.vue
@@ -37,8 +37,7 @@ export default {
   },
   methods: {
     keyCheck: function(e) {
-      if (e.ctrlKey) {
-        const appEl = document.querySelector("#app");
+      if (e.ctrlKey || e.metaKey) {
         if (e.keyCode === 38) {
           this.up = true;
         } else if (e.keyCode === 40) {

--- a/demo/src/slides/Intro.vue
+++ b/demo/src/slides/Intro.vue
@@ -7,9 +7,9 @@
       <twitter size="50px"/>
     </div>
     <div class="info">
-      <p>ctrl + ←↑↓→: to navigate</p>
-      <p>ctrl + Enter: to run code</p>
-      <p>ctrl + Alt: to reset code</p>
+      <p>ctrl/cmd + ←↑↓→: to navigate</p>
+      <p>ctrl/cmd + Enter: to run code</p>
+      <p>ctrl/cmd + Alt: to reset code</p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Hi @gautemo , thanks for your work on this.

This PR fixed two problems:

1. unused var error for `appEl `
2. There is no Ctrl key on macOS, so we added the `metaKey` for macOS which represents the cmd key.